### PR TITLE
COPY using wildcard for local Docker builds

### DIFF
--- a/docker/Dockerfile-dev
+++ b/docker/Dockerfile-dev
@@ -4,6 +4,6 @@ COPY / .
 RUN ./gradlew bootJar
 
 FROM adoptopenjdk/openjdk11:alpine-slim
-COPY --from=builder impl/build/libs/consent-bridge-0.11.0.jar /opt/nuts/consent-bridge-0.11.0.jar
+COPY --from=builder impl/build/libs/consent-bridge-*.jar /opt/nuts/consent-bridge.jar
 EXPOSE 8080 5563
-CMD ["java", "-jar", "/opt/nuts/consent-bridge-0.11.0.jar", "--spring.config.location=file:/opt/nuts/application.properties"]
+CMD ["java", "-jar", "/opt/nuts/consent-bridge.jar", "--spring.config.location=file:/opt/nuts/application.properties"]

--- a/docker/Dockerfile-local
+++ b/docker/Dockerfile-local
@@ -4,6 +4,6 @@
 #RUN ./gradlew bootJar
 
 FROM adoptopenjdk/openjdk11:alpine-slim
-COPY impl/build/libs/consent-bridge-0.11.0.jar /opt/nuts/consent-bridge-0.11.0.jar
+COPY impl/build/libs/consent-bridge-*.jar /opt/nuts/consent-bridge.jar
 EXPOSE 8080 5563
-CMD ["java", "-jar", "/opt/nuts/consent-bridge-0.11.0.jar", "--spring.config.location=file:/opt/nuts/application.properties"]
+CMD ["java", "-jar", "/opt/nuts/consent-bridge.jar", "--spring.config.location=file:/opt/nuts/application.properties"]


### PR DESCRIPTION
Local Docker builds: use wildcard (*) in JAR filename during COPY to prevent having to specify the exact version, making releasing easier.