### PR TITLE
Support signatures in JWS format

### DIFF
--- a/docs/_static/nuts-consent-bridge.yaml
+++ b/docs/_static/nuts-consent-bridge.yaml
@@ -65,7 +65,9 @@ components:
           type: string
           description: Hexidecimal SecureHash value
         signature:
-          $ref: '#/components/schemas/SignatureWithKey'
+          oneOf:
+            - $ref: "#/components/schemas/SignatureWithKey"
+            - $ref: "#/components/schemas/JWS"
     SignatureWithKey:
       required:
         - publicKey
@@ -79,6 +81,10 @@ components:
     JWK:
       type: object
       description: as described by https://tools.ietf.org/html/rfc7517. Modelled as object so libraries can parse the tokens themselves.
+      additionalProperties: {}
+    JWS:
+      type: string
+      description: as described by https://tools.ietf.org/html/rfc7515. Modelled as string so libraries can parse the signatures themselves.
       additionalProperties: {}
     FullConsentRequestState:
       required:

--- a/generated/src/main/kotlin/nl/nuts/consent/bridge/ConsentBridgeModule.kt
+++ b/generated/src/main/kotlin/nl/nuts/consent/bridge/ConsentBridgeModule.kt
@@ -1,0 +1,71 @@
+/*
+ * Nuts consent bridge
+ * Copyright (C) 2020 Nuts community
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package nl.nuts.consent.bridge
+
+import com.fasterxml.jackson.core.JsonParseException
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.TreeNode
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.module.SimpleModule
+import com.fasterxml.jackson.databind.node.ValueNode
+import nl.nuts.consent.bridge.model.PartyAttachmentSignature
+import nl.nuts.consent.bridge.model.SignatureWithKey
+
+class ConsentBridgeModule : SimpleModule() {
+
+    init {
+        addDeserializer(PartyAttachmentSignature::class.java, PASDeserializer())
+    }
+
+    private class PASDeserializer : StdDeserializer<PartyAttachmentSignature>(PartyAttachmentSignature::class.java) {
+        override fun deserialize(p: JsonParser, ctxt: DeserializationContext?): PartyAttachmentSignature =
+                p.readValueAsTree<TreeNode>().run {
+                    PartyAttachmentSignature(
+                            legalEntity = get("legalEntity").asValueNode().textValue(),
+                            attachment = get("attachment").asValueNode().textValue(),
+                            signature = parseSignature(p, get("signature")!!)
+                    )
+                }
+
+        fun TreeNode.asValueNode(): ValueNode =
+                when {
+                    isValueNode -> {
+                        this as ValueNode
+                    }
+                    else -> {
+                        throw JsonParseException(null, "Property is not a value")
+                    }
+                }
+
+        private fun parseSignature(p: JsonParser, node: TreeNode): Any =
+                when {
+                    node.isValueNode -> {
+                        node.asValueNode().textValue()
+                    }
+                    node.isObject -> {
+                        node.traverse(p.codec).readValueAs(SignatureWithKey::class.java)
+                    }
+                    else -> {
+                        throw JsonParseException(p, "Either JWS as string or SignatureWithKey as object was expected")
+                    }
+                }
+    }
+}

--- a/generated/src/main/kotlin/nl/nuts/consent/bridge/model/PartyAttachmentSignature.kt
+++ b/generated/src/main/kotlin/nl/nuts/consent/bridge/model/PartyAttachmentSignature.kt
@@ -2,7 +2,6 @@ package nl.nuts.consent.bridge.model
 
 import java.util.Objects
 import com.fasterxml.jackson.annotation.JsonProperty
-import nl.nuts.consent.bridge.model.SignatureWithKey
 import javax.validation.Valid
 import javax.validation.constraints.*
 
@@ -21,7 +20,7 @@ data class PartyAttachmentSignature (
         @JsonProperty("attachment") val attachment: String,
 
         @get:NotNull 
-        @JsonProperty("signature") val signature: SignatureWithKey
+        @JsonProperty("signature") val signature: Any
 ) {
 
 }

--- a/impl/src/main/kotlin/nl/nuts/consent/bridge/Serialization.kt
+++ b/impl/src/main/kotlin/nl/nuts/consent/bridge/Serialization.kt
@@ -20,10 +20,8 @@ package nl.nuts.consent.bridge
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.introspect.VisibilityChecker
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.registerKotlinModule
-import net.corda.nodeapi.internal.config.toConfigValue
 import java.text.SimpleDateFormat
 
 /**
@@ -36,8 +34,9 @@ class Serialization {
             val objectMapper = ObjectMapper()
             objectMapper.registerModule(JavaTimeModule())
             objectMapper.registerKotlinModule()
+            objectMapper.registerModule(ConsentBridgeModule())
 
-            objectMapper.setVisibility(objectMapper.getSerializationConfig().getDefaultVisibilityChecker()
+            objectMapper.setVisibility(objectMapper.serializationConfig.defaultVisibilityChecker
                     .withFieldVisibility(JsonAutoDetect.Visibility.ANY)
                     .withGetterVisibility(JsonAutoDetect.Visibility.NONE)
                     .withSetterVisibility(JsonAutoDetect.Visibility.NONE)

--- a/impl/src/test/kotlin/nl/nuts/consent/bridge/SerializationTest.kt
+++ b/impl/src/test/kotlin/nl/nuts/consent/bridge/SerializationTest.kt
@@ -1,0 +1,55 @@
+/*
+ * Nuts consent bridge
+ * Copyright (C) 2019 Nuts community
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package nl.nuts.consent.bridge
+
+import nl.nuts.consent.bridge.model.PartyAttachmentSignature
+import nl.nuts.consent.bridge.model.SignatureWithKey
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFails
+
+
+class SerializationTest {
+
+    @Test
+    fun `roundtrip PartyAttachmentSignature with JWS`() {
+        val expected = PartyAttachmentSignature("foobar", "1234", "JWS")
+        val actual = Serialization.objectMapper().readValue(Serialization.objectMapper().writeValueAsString(expected), PartyAttachmentSignature::class.java)
+        assertEquals(expected.legalEntity, actual.legalEntity)
+        assertEquals(expected.attachment, actual.attachment)
+        assertEquals(expected.signature, actual.signature)
+    }
+
+    @Test
+    fun `roundtrip PartyAttachmentSignature with SignatureWithKey`() {
+        val expected = PartyAttachmentSignature("foobar", "1234", SignatureWithKey(mapOf("foobar" to "bar"), "sigsigsig"))
+        val actual = Serialization.objectMapper().readValue(Serialization.objectMapper().writeValueAsString(expected), PartyAttachmentSignature::class.java)
+        assertEquals(expected.legalEntity, actual.legalEntity)
+        assertEquals(expected.attachment, actual.attachment)
+        assertEquals(expected.signature, actual.signature)
+    }
+
+    @Test
+    fun `PartyAttachmentSignature with unsupported signature format`() {
+        val input = PartyAttachmentSignature("foobar", "1234", listOf("foo", "bar"))
+        assertFails("Either JWS as string or SignatureWithKey as object was expected") {
+            Serialization.objectMapper().readValue(Serialization.objectMapper().writeValueAsString(input), PartyAttachmentSignature::class.java)
+        }
+    }
+}


### PR DESCRIPTION
Adds JWS support for attachment signatures. Change is backwards compatible; it supports signatures in both the old signature+pubkey format and JWS as string.

Fixes #60 